### PR TITLE
Test task updates

### DIFF
--- a/azext_iot/product/command_test_tasks.py
+++ b/azext_iot/product/command_test_tasks.py
@@ -34,6 +34,19 @@ def create(
         sleep(poll_interval)
         response = ap.show_test_task(test_id=test_id, task_id=task_id)
         status = response.status
+
+    # if a task of 'queueTestRun' is awaited, return the run results
+    if all(
+        [
+            wait,
+            status in final_statuses,
+            task_type == TaskType.QueueTestRun.value,
+            response.result_link
+        ]
+    ):
+            run_id = response.result_link.split('/')[-1]
+            return ap.show_test_run(test_id=test_id, run_id=run_id) if run_id else response
+
     return response
 
 

--- a/azext_iot/product/command_test_tasks.py
+++ b/azext_iot/product/command_test_tasks.py
@@ -28,6 +28,9 @@ def create(
                 test_id
             )
         )
+    if isinstance(response, dict):
+        raise CLIError(response)
+
     status = response.status
     task_id = response.id
     while all([wait, status, task_id]) and status not in final_statuses:
@@ -35,17 +38,17 @@ def create(
         response = ap.show_test_task(test_id=test_id, task_id=task_id)
         status = response.status
 
-    # if a task of 'queueTestRun' is awaited, return the run results
+    # if a task of 'queueTestRun' is awaited, return the run result
     if all(
         [
             wait,
             status in final_statuses,
             task_type == TaskType.QueueTestRun.value,
-            response.result_link
+            response.result_link,
         ]
     ):
-            run_id = response.result_link.split('/')[-1]
-            return ap.show_test_run(test_id=test_id, run_id=run_id) if run_id else response
+        run_id = response.result_link.split("/")[-1]
+        return ap.show_test_run(test_id=test_id, run_id=run_id) if run_id else response
 
     return response
 

--- a/azext_iot/tests/product/test_device_test_tasks_int.py
+++ b/azext_iot/tests/product/test_device_test_tasks_int.py
@@ -6,12 +6,19 @@
 
 import json
 from azure.cli.testsdk import LiveScenarioTest
+from azext_iot.product.shared import TaskType
 
 
 class TestProductDeviceTestTasks(LiveScenarioTest):
     def __init__(self, _):
         super(TestProductDeviceTestTasks, self).__init__(_)
-        self.kwargs.update({"device_test_id": "3beb0e67-33d0-4896-b69b-91c7b7ce8fab"})
+        self.kwargs.update(
+            {
+                "device_test_id": "3beb0e67-33d0-4896-b69b-91c7b7ce8fab",
+                "generate_task": TaskType.GenerateTestCases.value,
+                "queue_task": TaskType.QueueTestRun.value,
+            }
+        )
 
     def setup(self):
         return True
@@ -21,9 +28,9 @@ class TestProductDeviceTestTasks(LiveScenarioTest):
 
     def test_product_device_test_tasks(self):
 
-        # create task
+        # create task for GenerateTestCases
         created = self.cmd(
-            "iot product test task create -t {device_test_id}"
+            "iot product test task create -t {device_test_id} --type {generate_task} --wait"
         ).get_output_in_json()
         assert created["deviceTestId"] == self.kwargs["device_test_id"]
         assert json.dumps(created)
@@ -46,6 +53,13 @@ class TestProductDeviceTestTasks(LiveScenarioTest):
         show = self.cmd(
             "iot product test task show -t {device_test_id}", expect_failure=True
         )
+
+        # queue test run
+        created = self.cmd(
+            "iot product test task create -t {device_test_id} --type {queue_task} --wait"
+        ).get_output_in_json()
+        assert json.dumps(created)
+        assert json.dumps(created.get("certificationBadgeResults"))
 
         # delete test task
         self.cmd(

--- a/azext_iot/tests/product/test_device_test_tasks_unit.py
+++ b/azext_iot/tests/product/test_device_test_tasks_unit.py
@@ -11,7 +11,7 @@ import json
 import responses
 from knack.util import CLIError
 from azext_iot.product.command_test_tasks import create, delete, show
-from azext_iot.sdk.product.models import DeviceTestTask
+from azext_iot.sdk.product.models import DeviceTestTask, TestRun
 from azext_iot.product.shared import TaskType
 from azext_iot.product.shared import BASE_URL
 
@@ -19,13 +19,23 @@ mock_target = {}
 mock_target["entity"] = BASE_URL
 device_test_id = "12345"
 device_test_task_id = "54321"
+device_test_run_id = '67890'
 task_result = {
     "id": device_test_task_id,
     "status": "Queued",
     "type": "QueueTestRun",
     "deviceTestId": device_test_id,
-    "resultLink": "string",
+    "resultLink":'{}/testRuns/{}'.format(device_test_id, device_test_run_id)
 }
+
+run_result = {
+    "id": device_test_run_id,
+    "start_time": "start_time",
+    "end_time": "end_time",
+    "status": "Completed",
+    "certificationBadgeResults": []
+}
+
 queued_task = DeviceTestTask(
     id=device_test_task_id, device_test_id=device_test_id, status="Queued"
 )
@@ -36,7 +46,7 @@ running_task = DeviceTestTask(
     id=device_test_task_id, device_test_id=device_test_id, status="Running"
 )
 completed_task = DeviceTestTask(
-    id=device_test_task_id, device_test_id=device_test_id, status="Completed"
+    id=device_test_task_id, device_test_id=device_test_id, status="Completed",
 )
 
 task_result_body = json.dumps(task_result)
@@ -142,6 +152,8 @@ class TestTasksSDK(object):
     # create call
     @pytest.fixture(params=[202])
     def service_client_create(self, mocked_response, request):
+
+        # create test task
         mocked_response.add(
             method=responses.POST,
             url="{}/deviceTests/{}/tasks{}".format(
@@ -155,7 +167,7 @@ class TestTasksSDK(object):
         )
         yield mocked_response
 
-    # get call, includes create
+    # create task, get task, get run (for --wait)
     @pytest.fixture(params=[200])
     def service_client_create_wait(
         self, service_client_create, mocked_response, request
@@ -168,6 +180,18 @@ class TestTasksSDK(object):
             body=finished_task_result_body,
             headers={"x-ms-command-statuscode": str(request.param)},
             status=request.param,
+            content_type="application/json",
+            match_querystring=False,
+        )
+        # get completed queued test run
+        mocked_response.add(
+            method=responses.GET,
+            url="{}/deviceTests/{}/testRuns/{}{}".format(
+                mock_target["entity"], device_test_id, device_test_run_id, api_string
+            ),
+            body=json.dumps(run_result),
+            headers={"x-ms-command-statuscode": str(200)},
+            status=200,
             content_type="application/json",
             match_querystring=False,
         )
@@ -235,19 +259,30 @@ class TestTasksSDK(object):
     def test_sdk_task_create_wait(self, fixture_cmd, service_client_create_wait):
         result = create(fixture_cmd, test_id=device_test_id, wait=True, poll_interval=1)
         reqs = list(map(lambda call: call.request, service_client_create_wait.calls))
+
+        # Call 0 - create test task
         assert reqs[0].method == "POST"
         assert json.loads(reqs[0].body)["taskType"] == "QueueTestRun"
         url = reqs[0].url
         assert "deviceTests/{}/tasks".format(device_test_id) in url
 
+        # Call 1 - get task status
         assert reqs[1].method == "GET"
         url = reqs[1].url
         assert (
             "deviceTests/{}/tasks/{}".format(device_test_id, device_test_task_id) in url
         )
 
-        assert result.id == device_test_task_id
-        assert result.device_test_id == device_test_id
+        # Call 2 - get run results
+        assert reqs[2].method == "GET"
+        url = reqs[2].url
+        assert (
+            "deviceTests/{}/testRuns/{}".format(device_test_id, device_test_run_id) in url
+        )
+
+        # awaiting a queued test run should yield a test run object
+        assert isinstance(result, TestRun)
+        assert result.id == device_test_run_id
         assert result.status == "Completed"
 
     def test_sdk_task_delete(self, fixture_cmd, service_client_delete):


### PR DESCRIPTION
On create of a QueueTestRun task with `--wait=True` the function will now return the run result instead of the completed task.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
